### PR TITLE
fix ‘rfkill_device’ undeclared error

### DIFF
--- a/arch/arm/plat-s5p4418/nanopi2/device.c
+++ b/arch/arm/plat-s5p4418/nanopi2/device.c
@@ -1460,7 +1460,7 @@ static inline void _dwmci2_add_device(void) {
 /*------------------------------------------------------------------------------
  * RFKILL driver
  */
-#if defined(CONFIG_NXP_RFKILL)
+#if defined(CONFIG_RFKILL_NXP)
 struct rfkill_dev_data  rfkill_dev_data =
 {
 	.supply_name 	= "vgps_3.3V",	// vwifi_3.3V, vgps_3.3V


### PR DESCRIPTION
The macro "CONFIG_NXP_RFKILL" may cause 'rfkill_device’ undeclared error, the right macro is "CONFIG_RFKILL_NXP" as defined in the Kconfig.
